### PR TITLE
color status symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +55,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
+ "colored",
  "json",
  "semver",
  "tracing",
@@ -105,6 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +160,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "idna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.3", default-features = false, features = [
     "derive",
     "error-context",
 ] }
+colored = "2.0.0"
 json = "0.12"
 semver = "1.0"
 tracing = "0.1"

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, fmt::Display};
 
 use anyhow::{bail, Result};
+use colored::{ColoredString, Colorize};
 use semver::Version;
 use tracing::debug;
 use xshell::{cmd, Shell};
@@ -25,12 +26,12 @@ pub enum KrateStatus {
 
 impl KrateStatus {
     #[inline]
-    pub fn symbol(&self) -> &'static str {
+    pub fn symbol(&self) -> ColoredString {
         match self {
-            KrateStatus::Unknown => "?",
-            KrateStatus::Outdated => "✗",
-            KrateStatus::UpToDate => "✓",
-            KrateStatus::Ignored => ".",
+            KrateStatus::Unknown => "?".dimmed(),
+            KrateStatus::Outdated => "✗".red(),
+            KrateStatus::UpToDate => "✓".normal(),
+            KrateStatus::Ignored => ".".dimmed(),
         }
     }
 }


### PR DESCRIPTION
This PR colors the `outdated` ✗ red so it is easier to notice.

it also displays `unknown` and `ignored` in a slight gray.

![image](https://github.com/light4/cargo-installed/assets/81473300/21d31ad1-b15a-42e5-9ef5-7a23e5fa0256)

note:
I understand if this is something you don't like, you can then just close this PR
