### PR TITLE
multi thread get_all_krates()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
-use crates::print_krates;
 use tracing::debug;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use crates::print_krates;
 
 use crate::{
     args::Command,


### PR DESCRIPTION
This PR makes it so all requests to crates.io happen in parallel.

In my case, this improves the average performance from ~3 seconds to ~600 milliseconds.

the code could probably be majorly improved with the help of `Tokio`(probably also without it) but this would add a lot of new dependencies which I don't think is worth it.